### PR TITLE
Wait for Route53 changes to propagate

### DIFF
--- a/src/aws/route53/getChangeStatus.js
+++ b/src/aws/route53/getChangeStatus.js
@@ -1,0 +1,7 @@
+const getRoute53 = require('../sdk/getRoute53')
+
+const getChangeStatus = (id) =>
+  getRoute53().getChange({Id: id}).promise()
+    .then(data => data.Status)
+
+module.exports = getChangeStatus


### PR DESCRIPTION
Avoids these sporadic errors, which are caused by attempting to issue certs before records have propagated to all Route53 servers:

```
{
  "type": "urn:ietf:params:acme:error:orderNotReady",
  "detail": "Order's status (\"invalid\") is not acceptable for finalization",
  "status": 403
}
```

Waiting for the ChangeResourceRecordSets result to enter the INSYNC state ensures that the ACME server will see the new record regardless of which Route53 server it queries.

Fixes #33